### PR TITLE
Explicitly request XML from parldata API

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -16,7 +16,7 @@ OpenURI::Cache.cache_path = '.cache'
 @API_URL = 'http://api.parldata.eu/ge/parliament/%s'
 
 def noko_q(endpoint, h)
-  result = RestClient.get (@API_URL % endpoint), params: h
+  result = RestClient.get (@API_URL % endpoint), params: h, accept: :xml
   warn result.request.url
   doc = Nokogiri::XML(result)
   doc.remove_namespaces!


### PR DESCRIPTION
There has been a change recently which meant that the parldata API was
returning JSON by default, rather than the XML that we are using.

This change adds an explicit `Accept` header and sets it to XML so we
get back the correct data type.

This is the same change as https://github.com/everypolitician-scrapers/hungary-parldata/pull/1